### PR TITLE
Use rake-compile to compile the extension in dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /ext/Makefile
 /ext/mkmf.log
 /ext/rbkit_tracer.bundle
+/lib/rbkit_tracer.bundle
+/tmp
 /ext/rbkit_tracer.o
 Gemfile.lock
 *.so

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ source "https://rubygems.org"
 gem "allocation_stats", git: "git@github.com:srawlins/allocation_stats.git"
 gem "rbczmq"
 gem "msgpack"
+gem "rake-compiler"
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -13,16 +13,11 @@ but for now, this has to suffice.
 2. After that, run
 
 ```
-ruby extconf.rb
+bundle install
+bundle exec rake compile
 ```
 
-3. and then
-
-```
-make
-```
-
-4. Tasks to do:
+3. Tasks to do:
 
 * [X] implement support for disabling trackpoints
 * [X] implement support for cleaning zmq context on shutdown.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require "bundler/gem_tasks"
+
+require 'rake/extensiontask'
+
+Rake::ExtensionTask.new('rbkit_tracer') do |ext|
+  ext.ext_dir = 'ext'
+end

--- a/experiments/using_rbkit.rb
+++ b/experiments/using_rbkit.rb
@@ -1,5 +1,4 @@
 $:<< File.join(File.dirname(__FILE__), "../lib")
-$:<< File.join(File.dirname(__FILE__), "../ext")
 
 require 'rbkit'
 


### PR DESCRIPTION
This provides a convenient `rake compile` task. Running this allows you to add local path of rbkit to Gemfiles of other projects. For example, to use your development copy of rbkit inside `~/Projects/rbkit` in a rails app, add `gem 'rbkit', path: '~/Projects/rbkit'` to Gemfile of the rails app.
