### PR TITLE
Split API so as to allow users to enable tracepoints while starting server

### DIFF
--- a/ext/rbkit_tracer.c
+++ b/ext/rbkit_tracer.c
@@ -411,7 +411,7 @@ static VALUE send_objectspace_dump() {
 
 void Init_rbkit_tracer(void) {
   VALUE objectStatsModule = rb_define_module("Rbkit");
-  rb_define_module_function(objectStatsModule, "start_server", start_stat_server, -1);
+  rb_define_module_function(objectStatsModule, "start_stat_server", start_stat_server, -1);
   rb_define_module_function(objectStatsModule, "stop_server", stop_stat_server, 0);
   rb_define_module_function(objectStatsModule, "start_stat_tracing", start_stat_tracing, 0);
   rb_define_module_function(objectStatsModule, "stop_stat_tracing", stop_stat_tracing, 0);


### PR DESCRIPTION
Rbkit's public API is now split into : 
1. Rbkit.start_server : Simply starts the server and does nothing else.
2. Rbkit.start_profiling : Starts server and enables tracepoints.

Fixes #32 
