### PR TITLE
Use linked list of pages for holding object snapshot in memory

### DIFF
--- a/ext/rbkit_object_graph.h
+++ b/ext/rbkit_object_graph.h
@@ -1,7 +1,9 @@
 #ifndef RBKIT_OBJECT_GRAPH
 #define RBKIT_OBJECT_GRAPH
 
-struct ObjectData {
+#define RBKIT_OBJECT_DUMP_PAGE_SIZE 1000
+
+typedef struct _rbkit_object_data {
   const void * object_id;
   const char * class_name;
   void ** references;
@@ -9,17 +11,23 @@ struct ObjectData {
   char * file;
   unsigned long line;
   size_t size;
-  struct ObjectData *next;
-};
+} rbkit_object_data;
 
-struct ObjectDump {
-  size_t size;
-  struct ObjectData *first;
-  struct ObjectData *last;
+typedef struct _rbkit_object_dump_page {
+  rbkit_object_data data[RBKIT_OBJECT_DUMP_PAGE_SIZE];
+  size_t count;
+  struct _rbkit_object_dump_page *next;
+} rbkit_object_dump_page;
+
+typedef struct _rbkit_object_dump {
+  size_t page_count;
+  size_t object_count;
+  rbkit_object_dump_page *first;
+  rbkit_object_dump_page *last;
   st_table * object_table;
-};
+} rbkit_object_dump;
 
-struct ObjectDump * get_object_dump();
+rbkit_object_dump * get_object_dump();
 
 struct allocation_info {
   const char *path;

--- a/ext/rbkit_tracer.c
+++ b/ext/rbkit_tracer.c
@@ -306,7 +306,7 @@ int tracer_string_send(void *socket, const char *message) {
 
 static VALUE poll_for_request() {
   // Wait for 100 millisecond and check if there is a message
-  // we can't wait here indefenitely because ruby is not aware this is a 
+  // we can't wait here indefenitely because ruby is not aware this is a
   // blocking operation. Remember ruby releases GVL in a thread
   // whenever it encounters a known blocking operation.
   zmq_poll(items, 1, 100);
@@ -452,87 +452,94 @@ static VALUE send_objectspace_dump() {
   msgpack_sbuffer* buffer = msgpack_sbuffer_new();
   msgpack_packer* pk = msgpack_packer_new(buffer, msgpack_sbuffer_write);
 
-  struct ObjectDump * dump = get_object_dump(logger->object_table);
+  rbkit_object_dump * dump = get_object_dump(logger->object_table);
   pack_event_header(pk, "object_space_dump", 3);
   pack_string(pk, "payload");
   // Set size of array to hold all objects
-  msgpack_pack_array(pk, dump->size);
+  msgpack_pack_array(pk, dump->object_count);
 
   // Iterate through all object data
-  struct ObjectData * data = dump->first ;
-  for(;data != NULL; data = data->next ) {
-    /* ObjectData is a map that looks like this :
-     * {
-     *   object_id: <OBJECT_ID_IN_HEX>,
-     *   class: <CLASS_NAME>,
-     *   references: [<OBJECT_ID_IN_HEX>, <OBJECT_ID_IN_HEX>, ...],
-     *   file: <FILE_PATH>,
-     *   line: <LINE_NO>,
-     *   size: <SIZE>
-     * }
-     */
+  rbkit_object_dump_page * page = dump->first ;
+  while(page != NULL) {
+    rbkit_object_data *data;
+    size_t i = 0;
+    for(;i < page->count; i++) {
+      data = &(page->data[i]);
+      /* Object dump is a map that looks like this :
+       * {
+       *   object_id: <OBJECT_ID_IN_HEX>,
+       *   class: <CLASS_NAME>,
+       *   references: [<OBJECT_ID_IN_HEX>, <OBJECT_ID_IN_HEX>, ...],
+       *   file: <FILE_PATH>,
+       *   line: <LINE_NO>,
+       *   size: <SIZE>
+       * }
+       */
 
+      msgpack_pack_map(pk, 6);
 
-    msgpack_pack_map(pk, 6);
+      // Key1 : "object_id"
+      pack_string(pk, "object_id");
 
-    // Key1 : "object_id"
-    pack_string(pk, "object_id");
+      // Value1 : pointer address of object
+      char * object_id;
+      asprintf(&object_id, "%p", data->object_id);
+      pack_string(pk, object_id);
+      free(object_id);
 
-    // Value1 : pointer address of object
-    char * object_id;
-    asprintf(&object_id, "%p", data->object_id);
-    pack_string(pk, object_id); 
+      // Key2 : "class_name"
+      pack_string(pk, "class_name");
 
-    // Key2 : "class_name"
-    pack_string(pk, "class_name");
-
-    // Value2 : Class name of object
-    if(data->class_name == NULL) {
-      msgpack_pack_nil(pk);
-    } else {
-      pack_string(pk, data->class_name);
-    }
-
-    // Key3 : "references"
-    pack_string(pk, "references");
-
-    // Value3 : References held by the object
-    msgpack_pack_array(pk, data->reference_count);
-    if(data->reference_count != 0) {
-      size_t count = 0;
-      for(; count < data->reference_count; count++ ) {
-        char * object_id;
-        asprintf(&object_id, "%p", data->references[count]);
-        pack_string(pk, object_id);
+      // Value2 : Class name of object
+      if(data->class_name == NULL) {
+        msgpack_pack_nil(pk);
+      } else {
+        pack_string(pk, data->class_name);
       }
-      free(data->references);
+
+      // Key3 : "references"
+      pack_string(pk, "references");
+
+      // Value3 : References held by the object
+      msgpack_pack_array(pk, data->reference_count);
+      if(data->reference_count != 0) {
+        size_t count = 0;
+        for(; count < data->reference_count; count++ ) {
+          char * object_id;
+          asprintf(&object_id, "%p", data->references[count]);
+          pack_string(pk, object_id);
+          free(object_id);
+        }
+        free(data->references);
+      }
+
+      // Key4 : "file"
+      pack_string(pk, "file");
+
+      // Value4 : File path where object is defined
+      pack_string(pk, data->file);
+
+      // Key5 : "line"
+      pack_string(pk, "line");
+
+      // Value5 : Line no where object is defined
+      if(data->line == 0)
+        msgpack_pack_nil(pk);
+      else
+        msgpack_pack_unsigned_long(pk, data->line);
+
+      // Key6 : "size"
+      pack_string(pk, "size");
+
+      // Value6 : Size of the object in memory
+      if(data->size == 0)
+        msgpack_pack_nil(pk);
+      else
+        msgpack_pack_uint32(pk, data->size);
     }
-
-    // Key4 : "file"
-    pack_string(pk, "file");
-
-    // Value4 : File path where object is defined
-    pack_string(pk, data->file);
-
-    // Key5 : "line"
-    pack_string(pk, "line");
-
-    // Value5 : Line no where object is defined
-    if(data->line == 0)
-      msgpack_pack_nil(pk);
-    else
-      msgpack_pack_unsigned_long(pk, data->line);
-
-    // Key6 : "size"
-    pack_string(pk, "size");
-
-    // Value6 : Size of the object in memory
-    if(data->size == 0)
-      msgpack_pack_nil(pk);
-    else
-      msgpack_pack_uint32(pk, data->size);
-
-    free(data);
+    rbkit_object_dump_page * prev = page;
+    page = page->next;
+    free(prev);
   }
 
   // Send packed message over zmq


### PR DESCRIPTION
Also fixes crash( #44 ) and leaks(following `asprintf`). Closes #48.
