### PR TITLE
Disable homebrew based install of packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 bundler_args: "--without exclude_in_travis"
-env: RBKIT_NO_HOMEBREW=true
 rvm:
 - 2.1.3
 - 2.2.0

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -13,14 +13,15 @@ if ENV['RBKIT_DEV']
 end
 
 def check_and_install_with_homebrew(package)
-  return false if ENV['RBKIT_NO_HOMEBREW']
-  puts green("Looks like you're on OSX. Do you want to use homebrew to install #{package}? (y/Y/n/N) :")
-  use_brew = gets.chomp
-  if(use_brew.downcase == "y")
-    system("brew install #{package}")
-  else
-    false
-  end
+  # return false if ENV['RBKIT_NO_HOMEBREW']
+  # puts green("Looks like you're on OSX. Do you want to use homebrew to install #{package}? (y/Y/n/N) :")
+  # use_brew = gets.chomp
+  # if(use_brew.downcase == "y")
+  #   system("brew install #{package}")
+  # else
+  #   false
+  # end
+  false
 end
 
 def download_file(url)

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -12,18 +12,6 @@ if ENV['RBKIT_DEV']
   $defs << '-DRBKIT_DEV' # Set macro named RBKIT_DEV
 end
 
-def check_and_install_with_homebrew(package)
-  # return false if ENV['RBKIT_NO_HOMEBREW']
-  # puts green("Looks like you're on OSX. Do you want to use homebrew to install #{package}? (y/Y/n/N) :")
-  # use_brew = gets.chomp
-  # if(use_brew.downcase == "y")
-  #   system("brew install #{package}")
-  # else
-  #   false
-  # end
-  false
-end
-
 def download_file(url)
   if find_executable('curl')
     system("curl -L -O #{url}")
@@ -88,10 +76,6 @@ end
 unless(have_library("zmq") && have_header("zmq.h"))
   if Gem.win_platform?
     puts red("On Windows? You'll have to install zeromq by yourself.")
-  elsif RUBY_PLATFORM =~ /darwin/
-    unless check_and_install_with_homebrew("zeromq")
-      download_and_install_zeromq_from_source
-    end
   else
     download_and_install_zeromq_from_source
   end
@@ -105,10 +89,6 @@ end
 unless(have_library("msgpack") && have_header("msgpack.h"))
   if Gem.win_platform?
     puts red("On Windows? You'll have to install msgpack by yourself.")
-  elsif RUBY_PLATFORM =~ /darwin/
-    unless check_and_install_with_homebrew("msgpack")
-      download_and_install_msgpack_from_source
-    end
   else
     download_and_install_msgpack_from_source
   end


### PR DESCRIPTION
Homebrew will pull-in latest version of zeromq and msgpack
and i have noticed few issues when we uintentionally use
latest version of aforementioned packages from homebrew.

It is better to stick to version of libraries we know and understand