### PR TITLE
Add CPU profiling kwarg option to `start_server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,13 @@ profiling is not feasible. Returns true if server was started successfully.
 
 Arguments:
 
-|argument             | valid values | default value | description                                      |
-|---------------------|--------------|---------------|--------------------------------------------------|
-|pub_port             | nil, fixnum  | nil           | Override default message publishing port of 5555 |
-|request_port         | nil, fixnum  | nil           | Override default command listener port of 5556   |
-|enable_object_trace  | true/false   | true          | Enables object creation/deletion events          |
-|enable_gc_stats      | true/false   | true          | Enables GC stats which is sent every 5 seconds   |
+|argument               | valid values | default value | description                                      |
+|-----------------------|--------------|---------------|--------------------------------------------------|
+|pub_port               | nil, fixnum  | nil           | Override default message publishing port of 5555 |
+|request_port           | nil, fixnum  | nil           | Override default command listener port of 5556   |
+|enable_object_trace    | true/false   | true          | Enables object creation/deletion events          |
+|enable_gc_stats        | true/false   | true          | Enables GC stats which is sent every 5 seconds   |
+|enable_execution_trace | true/false   | true          | Enables CPU profiling                            |
 
 
 ## Development


### PR DESCRIPTION
* This feature is already in the master branch.