### PR TITLE
Fix bug in documentation of correlation-id

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -178,9 +178,9 @@ the following format :
 {
   event_type: object_space_dump
   timestamp: <timestamp in milliseconds>,
+  correlation_id: <ID_INDICATING_EVENT_THIS_MESSAGE_IS_PART_OF>,
   payload: [
     {
-      correlation_id: <ID_INDICATING_EVENT_THIS_MESSAGE_IS_PART_OF>,
       object_id: <OBJECT_ID>,
       class_name: <CLASS_NAME>,
       references: [<OBJECT_ID>, <OBJECT_ID>, ... ],

--- a/experiments/no_growth.rb
+++ b/experiments/no_growth.rb
@@ -3,18 +3,8 @@ $:<< File.join(File.dirname(__FILE__), "../ext")
 
 require 'rbkit'
 
-Rbkit.start_profiling(5555)
-
-class Foo
-  def initialize(name)
-    @name = name
-  end
-end
+Rbkit.start_profiling
 
 stuff = {}
-100.times do |i|
-  foo = Foo.new("hemant-#{i}")
-  stuff["name#{i}"] = "hemant-#{i}"
-end
-
+stuff["hello"] = "world"
 gets

--- a/spec/object_space_dump_spec.rb
+++ b/spec/object_space_dump_spec.rb
@@ -58,6 +58,8 @@ describe "Objectspace dump" do
     message_count, left_over_objects = object_count.divmod(1000)
     message_count += 1 unless left_over_objects.zero?
     expect(object_dump_messages.size).to eql(message_count)
+    expect(object_dump_messages.first[correlation_id]).to eql 1
+    expect(object_dump_messages.last[correlation_id]).to eql 1
   end
 
   it 'should record objects only once' do
@@ -92,11 +94,5 @@ describe "Objectspace dump" do
 
   it 'should record correct size' do
     expect(array_info.first[size_field]).to be > 0
-  end
-
-  it 'should record correct correlation_id' do
-    foo_correlation_id = foo_info.first[correlation_id]
-    expect(bar_info.first[correlation_id]).to eql foo_correlation_id
-    expect(array_info.first[correlation_id]).to eql foo_correlation_id
   end
 end


### PR DESCRIPTION
The correlation-id appears outside the actual payload, not inside.