### PR TITLE
Implement complete_message_count

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -50,17 +50,18 @@ enums used.
 ```ruby
 # Rbkit::MESSAGE_FIELDS
 {
-  'event_type'      =>  0,
-  'timestamp'       =>  1,
-  'payload'         =>  2,
-  'object_id'       =>  3,
-  'class_name'      =>  4,
-  'references'      =>  5,
-  'file'            =>  6,
-  'line'            =>  7,
-  'size'            =>  8,
-  'message_counter' =>  9,
-  'correlation_id'  => 10
+  'event_type'             =>  0,
+  'timestamp'              =>  1,
+  'payload'                =>  2,
+  'object_id'              =>  3,
+  'class_name'             =>  4,
+  'references'             =>  5,
+  'file'                   =>  6,
+  'line'                   =>  7,
+  'size'                   =>  8,
+  'message_counter'        =>  9,
+  'correlation_id'         => 10,
+  'complete_message_count' => 11
 }
 ```
 

--- a/ext/rbkit_event_packer.c
+++ b/ext/rbkit_event_packer.c
@@ -102,13 +102,17 @@ static void pack_hash_event(rbkit_hash_event *event, msgpack_packer *packer) {
 
 static void pack_object_space_dump_event(rbkit_object_space_dump_event *event, msgpack_packer *packer) {
   rbkit_object_dump *dump = event->dump;
-  msgpack_pack_map(packer, 4);
+  msgpack_pack_map(packer, 5);
   pack_event_header(packer, event->event_header.event_type);
 
   // Incrementing integer holding the correlation_id
   // indicating the event which the message belongs to
   msgpack_pack_int(packer, rbkit_message_field_correlation_id);
   msgpack_pack_int(packer, event->correlation_id);
+  
+  // dump total number of messages in batch
+  msgpack_pack_int(packer, rbkit_message_field_complete_message_count);
+  msgpack_pack_int(packer, event->object_count);
 
   msgpack_pack_int(packer, rbkit_message_field_payload);
 
@@ -268,6 +272,7 @@ VALUE rbkit_message_fields_as_hash() {
   rb_hash_aset(events, ID2SYM(rb_intern("size")), INT2FIX(rbkit_message_field_size));
   rb_hash_aset(events, ID2SYM(rb_intern("message_counter")), INT2FIX(rbkit_message_field_message_counter));
   rb_hash_aset(events, ID2SYM(rb_intern("correlation_id")), INT2FIX(rbkit_message_field_correlation_id));
+  rb_hash_aset(events, ID2SYM(rb_intern("complete_message_count")), INT2FIX(rbkit_message_field_complete_message_count));
   OBJ_FREEZE(events);
   return events;
 }

--- a/ext/rbkit_event_packer.h
+++ b/ext/rbkit_event_packer.h
@@ -21,7 +21,8 @@ typedef enum _rbkit_message_fields {
   rbkit_message_field_line,
   rbkit_message_field_size,
   rbkit_message_field_message_counter,
-  rbkit_message_field_correlation_id
+  rbkit_message_field_correlation_id,
+  rbkit_message_field_complete_message_count
 } rbkit_message_fields;
 
 VALUE rbkit_message_fields_as_hash();

--- a/spec/object_space_dump_spec.rb
+++ b/spec/object_space_dump_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'support/have_message_matcher'
 require 'msgpack'
+require 'pry'
 
 describe "Objectspace dump" do
   let(:payload) { Rbkit::MESSAGE_FIELDS[:payload] }
@@ -12,6 +13,8 @@ describe "Objectspace dump" do
   let(:size_field) { Rbkit::MESSAGE_FIELDS[:size] }
   let(:references) { Rbkit::MESSAGE_FIELDS[:references] }
   let(:correlation_id) { Rbkit::MESSAGE_FIELDS[:correlation_id] }
+  let(:complete_message_count) { Rbkit::MESSAGE_FIELDS[:complete_message_count] }
+
   let(:object_dump_messages) do
     @message_list[payload]
       .select{|x| x[event_type] == Rbkit::EVENT_TYPES[:object_space_dump]}
@@ -47,6 +50,12 @@ describe "Objectspace dump" do
     packed_message = Rbkit.get_queued_messages
     Rbkit.stop_server
     @message_list  = MessagePack.unpack packed_message
+  end
+
+  it "should have count of all messages" do
+    total_message_count = object_dump_messages.first[complete_message_count]
+    expect(total_message_count).to_not be_nil
+    expect(total_message_count).to be > 0
   end
 
   it "should be part of message list" do

--- a/spec/object_space_dump_spec.rb
+++ b/spec/object_space_dump_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'support/have_message_matcher'
 require 'msgpack'
-require 'pry'
 
 describe "Objectspace dump" do
   let(:payload) { Rbkit::MESSAGE_FIELDS[:payload] }


### PR DESCRIPTION
When a large message is split, we need to
tell client that how many messages will be there in total.

This information can be used by the client to determine
when it has received the complete message.