### PR TITLE
Add note on recommended versions of zmq, msgpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ On Linux - we recommend to download these libraries
 from their respective home pages and manually compiling
 and installing.
 
+Recommended versions are:
+
+Zeromq: 4.0.5_2
+Msgpack: 0.5.9
+
 #### Clone the repo
 
 `git clone git@github.com:code-mancers/rbkit.git`


### PR DESCRIPTION
There is a change in the API of these two libs in the latest versions as of
this date.