### PR TITLE
Fix segfault that happens after server is stopped

### DIFF
--- a/ext/rbkit_server.c
+++ b/ext/rbkit_server.c
@@ -385,9 +385,7 @@ static VALUE stop_stat_server() {
 static VALUE send_hash_as_event(int argc, VALUE *argv, VALUE self) {
   /*
    * Check if the server connection is available before trying to pack GC stat
-   * information into msgpack buffers. By checking if the logger variable is
-   * initiated or not, we achieve this. If the server has been stopped, we free
-   * the logger pointer and set it to 0. Refer to `stop_stat_server` method.
+   * information into msgpack buffers.
    */
   if(logger == 0)
     return Qfalse;

--- a/ext/rbkit_server.c
+++ b/ext/rbkit_server.c
@@ -383,6 +383,14 @@ static VALUE stop_stat_server() {
 }
 
 static VALUE send_hash_as_event(int argc, VALUE *argv, VALUE self) {
+  /*
+   * Check if the server connection is available before trying to pack GC stat
+   * information into msgpack buffers. By checking if the logger variable is
+   * initiated or not, we achieve this. If the server has been stopped, we free
+   * the logger pointer and set it to 0. Refer to `stop_stat_server` method.
+   */
+  if(logger == 0)
+    return Qfalse;
   VALUE hash_object;
   VALUE event_type;
   msgpack_sbuffer *buffer;


### PR DESCRIPTION
Reproduction script:
(This is the same code present in `examples/benchmark.rb`. Refer to the last benchmark script)

     server = Rbkit.start_profiling(pub_port: 9999, request_port: 9998)
     server.stop

     # Running code after disabling rbkit
     do_stuff

Before this change, that script will abort. One of the issues is a mistake in
naming of the GC stat stop flag in `rbkit/server.rb`.  There are two different
flags being used in that file: `profiler_stop_thread` and
`stop_profiler_thread`. `profiler_stop_thread` is now removed and
`stop_profiler_thread` is used everywhere instead.


Just to ensure that the message packing of GC stats doesn't happen if the server is not started, the `send_hash_as_event` method is short-circuited early.