### PR TITLE
Parallelize tests by spawning test processes in separate threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 os:
 - linux
 - osx
-script: bundle exec rake run_spec
+script: bundle exec rake
 notifications:
   hipchat:
     rooms:

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ make
 #### Run the tests
 
 ```
-bundle exec rake run_spec
+bundle exec rake
 ```
 
 ## TODO


### PR DESCRIPTION
    Since we are running each test file in a separate thread,
    we can spawn these processes from separate threads and keep collecting
    the exit statuses in parallel instead of blocking for each process to
    come out. This halves the time taken for the test suite to execute.