### PR TITLE
Check for msgpack version and switch bin packing

### DIFF
--- a/ext/rbkit_event_packer.c
+++ b/ext/rbkit_event_packer.c
@@ -12,8 +12,8 @@ static void pack_string(msgpack_packer *packer, const char *string) {
 		msgpack_pack_raw(packer, length);
 		msgpack_pack_raw_body(packer, string, length);
 #else
-		msgpack_pack_bin(packer, length);
-		msgpack_pack_bin_body(packer, string, length);
+		msgpack_pack_str(packer, length);
+		msgpack_pack_str_body(packer, string, length);
 #endif
   }
 }

--- a/ext/rbkit_event_packer.c
+++ b/ext/rbkit_event_packer.c
@@ -8,8 +8,13 @@ static void pack_string(msgpack_packer *packer, const char *string) {
     msgpack_pack_nil(packer);
   } else {
     int length = (int)strlen(string);
-    msgpack_pack_raw(packer, length);
-    msgpack_pack_raw_body(packer, string, length);
+#if defined(MSGPACK_VERSION_MAJOR) && MSGPACK_VERSION_MAJOR < 1
+		msgpack_pack_raw(packer, length);
+		msgpack_pack_raw_body(packer, string, length);
+#else
+		msgpack_pack_bin(packer, length);
+		msgpack_pack_bin_body(packer, string, length);
+#endif
   }
 }
 


### PR DESCRIPTION
msgpack version > 1.0 changes the API for raw byte data to use
`msgpack_pack_bin` function instead of `msgpack_pack_raw` which was the
function to be used for earlier versions. We check the
`MSGPACK_VERSION_MAJOR` constant value and switch the function accordingly.